### PR TITLE
Use Firestore realtime updates

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     const monitorListDiv = document.getElementById('monitor-list');
     const restaurantNameElement = document.getElementById('restaurant-name');
     const restaurantLogoElement = document.getElementById('restaurant-logo');
@@ -10,6 +10,10 @@ document.addEventListener('DOMContentLoaded', () => {
     let trackedTickets = new Set();
 
     let currentUser = null; // Variable to store current user
+    let orderHistory = []; // Orders fetched from Firestore
+
+    const { db } = await import('./firebase-init.js');
+    const { collection, onSnapshot, query, where } = await import('https://www.gstatic.com/firebasejs/9.6.1/firebase-firestore.js');
 
     // Function to get the current user from localStorage
     const getCurrentUser = () => {
@@ -17,26 +21,19 @@ document.addEventListener('DOMContentLoaded', () => {
         return user ? JSON.parse(user) : null;
     };
 
-    // Helper to get restaurant-specific storage key
-    const getStorageKey = (key) => {
-        if (currentUser && currentUser.role === 'restaurant' && currentUser.id) {
-            return `${currentUser.id}_${key}`;
-        } else if (currentUser && currentUser.role === 'admin') {
-            return `admin_default_${key}`; // Admin uses a default set of data
+    // Listen for order updates in Firestore
+    let unsubscribeOrders = null;
+    const listenToOrders = () => {
+        if (!currentUser) return;
+        if (unsubscribeOrders) unsubscribeOrders();
+        let ordersRef = collection(db, 'orders');
+        if (currentUser.role === 'restaurant') {
+            ordersRef = query(ordersRef, where('restaurantId', '==', currentUser.id));
         }
-        // If no user or unrecognized role, fall back to a generic key, though this case should ideally be prevented
-        console.warn("Attempting to access storage without a valid user context. Data might not be isolated.");
-        return key; 
-    };
-
-    // Function to load order history from localStorage
-    const loadOrderHistory = () => {
-        if (!currentUser) {
-            console.error("Cannot load order history: No user logged in.");
-            return [];
-        }
-        const history = localStorage.getItem(getStorageKey('orderHistory'));
-        return history ? JSON.parse(history) : [];
+        unsubscribeOrders = onSnapshot(ordersRef, (snapshot) => {
+            orderHistory = snapshot.docs.map(doc => doc.data());
+            renderMonitorView();
+        });
     };
 
     // Function to load settings (restaurant name and logo) from localStorage
@@ -209,7 +206,7 @@ document.addEventListener('DOMContentLoaded', () => {
         trackedTicketsDisplay.classList.remove('hidden');
         trackedTicketsList.innerHTML = '';
 
-        const history = loadOrderHistory();
+        const history = orderHistory;
         
         Array.from(trackedTickets).forEach(ticketNumber => {
             const order = history.find(o => o.id === ticketNumber);
@@ -234,7 +231,7 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        const history = loadOrderHistory();
+        const history = orderHistory;
         monitorListDiv.innerHTML = ''; // Clear current monitor view
 
         // Filter orders by status
@@ -356,41 +353,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     `;
     document.head.appendChild(style);
-
     // Event listeners
     addTicketBtn.addEventListener('click', addTicket);
 
-    // Initial load of currentUser
+    // Initial load of currentUser and start listening to orders
     currentUser = getCurrentUser();
-
-    // Initial render when the monitor window opens
-    updateHeader(); // Update header first
-    renderMonitorView();
-
-    // Listen for storage events from other windows (e.g., the main page or settings)
-    // This allows the monitor to update automatically when an order status changes or history is reset
-    window.addEventListener('storage', (event) => {
-        // Re-evaluate currentUser on storage event, in case the logged-in user changed in main tab
-        const newCurrentUser = getCurrentUser();
-        // If the current user context changes from what was initially loaded, reload the page
-        // This is crucial for handling user switches (e.g., admin logs in, then restaurant user logs in)
-        if (!currentUser || !newCurrentUser || currentUser.id !== newCurrentUser.id || currentUser.role !== newCurrentUser.role) {
-            location.reload(); // Force a full reload to apply new user context
-            return;
-        }
-
-        // Check if the key that changed is 'orderHistory', 'lastOrderNumber', or 'appSettings'
-        // This relies on the getStorageKey() correctly identifying the current restaurant's data
-        const relevantOrderHistoryKey = getStorageKey('orderHistory');
-        const relevantLastOrderNumberKey = getStorageKey('lastOrderNumber');
-        const relevantAppSettingsKey = currentUser.role === 'restaurant' ? `restaurant_${currentUser.id}_appSettings` : `admin_appSettings`;
-
-        if (event.key === relevantOrderHistoryKey || event.key === relevantLastOrderNumberKey || event.key === 'orderHistoryUpdate') {
-            console.log('Storage event detected for order history, re-rendering monitor.');
-            renderMonitorView(); // Re-render the view with the updated order data
-        } else if (event.key === relevantAppSettingsKey) {
-            console.log('Storage event detected for app settings, updating header.');
-            updateHeader(); // Update restaurant name/logo
-        }
-    });
+    updateHeader();
+    listenToOrders();
 });

--- a/monitor_details.js
+++ b/monitor_details.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     const detailMonitorListDiv = document.getElementById('detail-monitor-list');
     const restaurantNameElement = document.getElementById('restaurant-name-details');
     const restaurantLogoElement = document.getElementById('restaurant-logo-details');
@@ -29,6 +29,10 @@ document.addEventListener('DOMContentLoaded', () => {
     let currentUser = null;
     let isAuthenticated = false;
     let currentRestaurantId = null;
+    let orderHistory = [];
+
+    const { db } = await import('./firebase-init.js');
+    const { collection, onSnapshot, query, where, getDocs, doc, updateDoc } = await import('https://www.gstatic.com/firebasejs/9.6.1/firebase-firestore.js');
 
     // Security check function
     const checkSecurityAccess = () => {
@@ -130,27 +134,18 @@ document.addEventListener('DOMContentLoaded', () => {
             monitorDetailsHeader.appendChild(authIndicator);
         }
         
-        // Load settings
-        loadAppSettings();
-        updateHeader();
-        
-        // Immediately render all orders
-        renderDetailMonitorView();
-        
-        // Set up storage listener
-        setupStorageListener();
-    };
+          // Load settings
+          loadAppSettings();
+          updateHeader();
+
+          // Listen to Firestore orders
+          listenToOrders(restaurantId);
+      };
 
     // Function to get the current user from localStorage
     const getCurrentUser = () => {
         const user = localStorage.getItem('currentUser');
         return user ? JSON.parse(user) : null;
-    };
-
-    // Helper to get restaurant-specific storage key
-    const getStorageKey = (key, restId = null) => {
-        const baseKey = restId || currentRestaurantId || localStorage.getItem('monitorDetailsRestaurantId');
-        return `${baseKey}_${key}`;
     };
 
     // Function to load restaurants
@@ -159,12 +154,18 @@ document.addEventListener('DOMContentLoaded', () => {
         return restaurants ? JSON.parse(restaurants) : [];
     };
 
-    // Function to load order history from localStorage
-    const loadOrderHistory = () => {
-        if (!currentRestaurantId) return [];
-        
-        const history = localStorage.getItem(getStorageKey('orderHistory'));
-        return history ? JSON.parse(history) : [];
+    // Firestore real-time listener for orders
+    let unsubscribeOrders = null;
+    const listenToOrders = (restaurantId) => {
+        if (unsubscribeOrders) unsubscribeOrders();
+        let ordersRef = collection(db, 'orders');
+        if (restaurantId) {
+            ordersRef = query(ordersRef, where('restaurantId', '==', restaurantId));
+        }
+        unsubscribeOrders = onSnapshot(ordersRef, (snapshot) => {
+            orderHistory = snapshot.docs.map(doc => doc.data());
+            renderDetailMonitorView();
+        });
     };
 
     // Function to load settings from localStorage
@@ -193,19 +194,23 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    // Function to update order status in localStorage and re-render
-    const updateOrderStatus = (orderId, newStatus) => {
+    // Function to update order status in Firestore
+    const updateOrderStatus = async (orderId, newStatus) => {
         if (!currentRestaurantId) return;
 
-        const history = loadOrderHistory();
-        const orderIndex = history.findIndex(order => order.id === parseInt(orderId, 10));
+        const existing = orderHistory.find(o => o.id === parseInt(orderId, 10));
+        const oldStatus = existing ? existing.status : null;
 
-        if (orderIndex > -1) {
-            const oldOrder = history[orderIndex];
-            const oldStatus = oldOrder.status;
-            history[orderIndex].status = newStatus;
-            localStorage.setItem(getStorageKey('orderHistory'), JSON.stringify(history));
-            renderDetailMonitorView();
+        const snapshot = await getDocs(collection(db, 'orders'));
+        let targetDoc = null;
+        snapshot.forEach(docSnap => {
+            if (docSnap.data().id === parseInt(orderId, 10)) {
+                targetDoc = docSnap;
+            }
+        });
+
+        if (targetDoc) {
+            await updateDoc(doc(db, 'orders', targetDoc.id), { status: newStatus });
 
             if (oldStatus !== 'Listo' && newStatus === 'Listo') {
                 try {
@@ -215,16 +220,13 @@ document.addEventListener('DOMContentLoaded', () => {
                     const savedVolume = parseFloat(localStorage.getItem(`restaurant_${currentRestaurantId}_appVolume`) || '1');
                     gainNode.gain.value = savedVolume;
 
-                    fetch('/ready_sound.mp3')
-                        .then(response => response.arrayBuffer())
-                        .then(arrayBuffer => audioContext.decodeAudioData(arrayBuffer))
-                        .then(audioBuffer => {
-                            const source = audioContext.createBufferSource();
-                            source.buffer = audioBuffer;
-                            source.connect(gainNode);
-                            source.start(0);
-                        })
-                        .catch(error => console.error('Error playing sound:', error));
+                    const response = await fetch('/ready_sound.mp3');
+                    const arrayBuffer = await response.arrayBuffer();
+                    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+                    const source = audioContext.createBufferSource();
+                    source.buffer = audioBuffer;
+                    source.connect(gainNode);
+                    source.start(0);
                 } catch (e) {
                     console.warn('AudioContext not available or active, cannot play sound:', e);
                 }
@@ -236,7 +238,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderDetailMonitorView = () => {
         detailMonitorListDiv.innerHTML = '';
 
-        const history = loadOrderHistory();
+        const history = orderHistory;
         
         if (history.length === 0) {
             detailMonitorListDiv.innerHTML = '<p style="color: #6A1B9A; font-weight: bold;">No hay pedidos registrados en el sistema.</p>';
@@ -318,23 +320,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
 
-    // Setup storage listener for real-time updates
-    const setupStorageListener = () => {
-        window.addEventListener('storage', (event) => {
-            if (!currentRestaurantId) return;
-            
-            const relevantOrderHistoryKey = getStorageKey('orderHistory');
-            const relevantAppSettingsKey = `restaurant_${currentRestaurantId}_appSettings`;
-
-            if (event.key === relevantOrderHistoryKey || event.key === 'orderHistoryUpdate') {
-                console.log('Storage event detected for order history, re-rendering detail monitor.');
-                renderDetailMonitorView();
-            } else if (event.key === relevantAppSettingsKey) {
-                console.log('Storage event detected for app settings, updating detail monitor header.');
-                updateHeader();
-            }
-        });
-    };
 
     // Clear authentication on page load/refresh
     clearAuthentication();


### PR DESCRIPTION
## Summary
- Switch monitor pages to live Firestore `orders` updates via `onSnapshot`
- Persist order status changes directly to Firestore
- Drop localStorage listeners and obsolete keys

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f86f9134c8327a6801b8fbcf37b4f