### PR TITLE
Scope orders by restaurant in Firestore

### DIFF
--- a/monitor_details.js
+++ b/monitor_details.js
@@ -201,13 +201,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const existing = orderHistory.find(o => o.id === parseInt(orderId, 10));
         const oldStatus = existing ? existing.status : null;
 
-        const snapshot = await getDocs(collection(db, 'orders'));
-        let targetDoc = null;
-        snapshot.forEach(docSnap => {
-            if (docSnap.data().id === parseInt(orderId, 10)) {
-                targetDoc = docSnap;
-            }
-        });
+        const ordersRef = collection(db, 'orders');
+        const q = query(ordersRef, where('id', '==', parseInt(orderId, 10)), where('restaurantId', '==', currentRestaurantId));
+        const snapshot = await getDocs(q);
+        const targetDoc = snapshot.docs[0];
 
         if (targetDoc) {
             await updateDoc(doc(db, 'orders', targetDoc.id), { status: newStatus });

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 import { db, auth, signInWithEmailAndPassword, onAuthStateChanged, signOut } from './firebase-init.js';
-import { doc, getDoc, collection, getDocs, setDoc, updateDoc, deleteDoc, addDoc, runTransaction } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-firestore.js";
+import { doc, getDoc, collection, getDocs, setDoc, updateDoc, deleteDoc, addDoc, runTransaction, query, where } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-firestore.js";
 
 document.addEventListener('DOMContentLoaded', () => {
     const placeOrderBtn = document.getElementById('place-order-btn');
@@ -546,7 +546,11 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const loadOrderHistory = async () => {
-        const snapshot = await getDocs(collection(db, 'orders'));
+        let ordersRef = collection(db, 'orders');
+        if (currentUser && currentUser.role === 'restaurant') {
+            ordersRef = query(ordersRef, where('restaurantId', '==', currentUser.id));
+        }
+        const snapshot = await getDocs(ordersRef);
         const history = [];
         snapshot.forEach(docSnap => {
             history.push(docSnap.data());
@@ -559,13 +563,16 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const updateOrderStatus = async (orderId, newStatus) => {
-        const snapshot = await getDocs(collection(db, 'orders'));
-        let targetDoc = null;
-        snapshot.forEach(docSnap => {
-            if (docSnap.data().id === parseInt(orderId, 10)) {
-                targetDoc = docSnap;
-            }
-        });
+        const idNum = parseInt(orderId, 10);
+        let ordersRef = collection(db, 'orders');
+        let q;
+        if (currentUser && currentUser.role === 'restaurant') {
+            q = query(ordersRef, where('id', '==', idNum), where('restaurantId', '==', currentUser.id));
+        } else {
+            q = query(ordersRef, where('id', '==', idNum));
+        }
+        const snapshot = await getDocs(q);
+        const targetDoc = snapshot.docs[0];
 
         if (targetDoc) {
             const oldOrder = targetDoc.data();
@@ -905,13 +912,15 @@ document.addEventListener('DOMContentLoaded', () => {
             updateDailySummary();
         }
 
-        const snapshot = await getDocs(collection(db, 'orders'));
-        let targetDoc = null;
-        snapshot.forEach(docSnap => {
-            if (docSnap.data().id === editingOrderId) {
-                targetDoc = docSnap;
-            }
-        });
+        let ordersRef = collection(db, 'orders');
+        let q;
+        if (currentUser && currentUser.role === 'restaurant') {
+            q = query(ordersRef, where('id', '==', editingOrderId), where('restaurantId', '==', currentUser.id));
+        } else {
+            q = query(ordersRef, where('id', '==', editingOrderId));
+        }
+        const snapshot = await getDocs(q);
+        const targetDoc = snapshot.docs[0];
 
         if (targetDoc) {
             await updateDoc(doc(db, 'orders', targetDoc.id), updatedOrder);
@@ -1417,7 +1426,8 @@ document.addEventListener('DOMContentLoaded', () => {
             extraPayment: null,
             timestamp: Date.now(),
             status: "Preparando",
-            orderType: orderType
+            orderType: orderType,
+            restaurantId: currentUser ? currentUser.id : null
         };
 
         await addOrderToHistory(newOrder);
@@ -1863,7 +1873,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const confirmed = confirm('¿Estás seguro de que quieres restablecer todo el historial de pedidos? Esta acción no se puede deshacer.');
 
         if (confirmed) {
-            const ordersSnapshot = await getDocs(collection(db, 'orders'));
+            let ordersRef = collection(db, 'orders');
+            if (currentUser && currentUser.role === 'restaurant') {
+                ordersRef = query(ordersRef, where('restaurantId', '==', currentUser.id));
+            }
+            const ordersSnapshot = await getDocs(ordersRef);
             const deletions = ordersSnapshot.docs.map(d => deleteDoc(doc(db, 'orders', d.id)));
             await Promise.all(deletions);
             await setDoc(doc(db, 'counters', 'orderNumber'), { value: 0 });


### PR DESCRIPTION
## Summary
- Filter order history queries by restaurant ID
- Store `restaurantId` on new orders and when editing
- Restrict history reset and status updates to the current restaurant

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f6931994883279200f261f25195c5