### PR TITLE
feat: use Firestore for settings and access control

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -12,14 +12,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     let currentUser = null; // Variable to store current user
     let orderHistory = []; // Orders fetched from Firestore
 
-    const { db } = await import('./firebase-init.js');
-    const { collection, onSnapshot, query, where } = await import('https://www.gstatic.com/firebasejs/9.6.1/firebase-firestore.js');
-
-    // Function to get the current user from localStorage
-    const getCurrentUser = () => {
-        const user = localStorage.getItem('currentUser');
-        return user ? JSON.parse(user) : null;
-    };
+    const { db, auth, onAuthStateChanged } = await import('./firebase-init.js');
+    const { collection, onSnapshot, query, where, doc, getDoc } = await import('https://www.gstatic.com/firebasejs/9.6.1/firebase-firestore.js');
 
     // Listen for order updates in Firestore
     let unsubscribeOrders = null;
@@ -48,21 +42,27 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     };
 
-    // Function to load settings (restaurant name and logo) from localStorage
-    const loadSettings = () => {
+    // Function to load settings (restaurant name and logo) from Firestore
+    const loadSettings = async () => {
         if (!currentUser) {
             console.error("Cannot load settings: No user logged in.");
             return {};
         }
-        // Settings are now user-specific
-        const settingsKey = currentUser.role === 'restaurant' ? `restaurant_${currentUser.id}_appSettings` : `admin_appSettings`;
-        const settings = localStorage.getItem(settingsKey);
-        return settings ? JSON.parse(settings) : {};
+        try {
+            const docRef = currentUser.role === 'restaurant'
+                ? doc(db, 'restaurants', currentUser.id)
+                : doc(db, 'users', currentUser.uid);
+            const docSnap = await getDoc(docRef);
+            return docSnap.exists() ? (docSnap.data().settings || {}) : {};
+        } catch (e) {
+            console.error('Error loading settings:', e);
+            return {};
+        }
     };
 
     // Function to update restaurant name and logo on the monitor
-    const updateHeader = () => {
-        const settings = loadSettings();
+    const updateHeader = async () => {
+        const settings = await loadSettings();
         const restaurantName = settings.restaurantName || 'Monitor de Pedidos';
         const restaurantLogoDataUrl = settings.restaurantLogoUrl; // Now expects a Data URL
 
@@ -368,8 +368,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Event listeners
     addTicketBtn.addEventListener('click', addTicket);
 
-    // Initial load of currentUser and start listening to orders
-    currentUser = getCurrentUser();
-    updateHeader();
-    listenToOrders();
+    onAuthStateChanged(auth, async (user) => {
+        if (user) {
+            try {
+                const userDoc = await getDoc(doc(db, 'users', user.uid));
+                currentUser = userDoc.exists() ? { uid: user.uid, ...userDoc.data() } : null;
+            } catch (e) {
+                console.error('Error fetching user data:', e);
+                currentUser = null;
+            }
+            await updateHeader();
+            listenToOrders();
+        } else {
+            currentUser = null;
+        }
+        renderMonitorView();
+    });
 });

--- a/monitor_details.js
+++ b/monitor_details.js
@@ -31,29 +31,30 @@ document.addEventListener('DOMContentLoaded', async () => {
     let currentRestaurantId = null;
     let orderHistory = [];
 
-    const { db } = await import('./firebase-init.js');
+    const { db, auth, onAuthStateChanged } = await import('./firebase-init.js');
     const { collection, onSnapshot, query, where, getDocs, doc, updateDoc, getDoc } = await import('https://www.gstatic.com/firebasejs/9.6.1/firebase-firestore.js');
 
-    // Security check function
+    // Security check function using Firebase Auth
     const checkSecurityAccess = () => {
-        const storedAuth = localStorage.getItem('monitorDetailsAuthenticated');
-        const storedId = localStorage.getItem('monitorDetailsRestaurantId');
-        
-        if (storedAuth === 'true' && storedId) {
-            isAuthenticated = true;
-            currentRestaurantId = storedId;
-            return true;
-        }
-        
-        return false;
-    };
-
-    // Clear authentication on page refresh/load
-    const clearAuthentication = () => {
-        localStorage.removeItem('monitorDetailsAuthenticated');
-        localStorage.removeItem('monitorDetailsRestaurantId');
-        isAuthenticated = false;
-        currentRestaurantId = null;
+        return new Promise((resolve) => {
+            onAuthStateChanged(auth, async (user) => {
+                if (user) {
+                    try {
+                        const userDoc = await getDoc(doc(db, 'users', user.uid));
+                        currentUser = userDoc.exists() ? { uid: user.uid, ...userDoc.data() } : null;
+                        if (currentUser && currentUser.role === 'restaurant' && currentUser.id) {
+                            isAuthenticated = true;
+                            currentRestaurantId = currentUser.id;
+                            resolve(true);
+                            return;
+                        }
+                    } catch (e) {
+                        console.error('Error fetching user data:', e);
+                    }
+                }
+                resolve(false);
+            });
+        });
     };
 
     // Show security modal
@@ -61,15 +62,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         securityModal.classList.remove('hidden');
         void securityModal.offsetWidth;
         securityModal.classList.add('active');
-        
+
         const securityInput = document.getElementById('security-restaurant-id');
         const securityConfirm = document.getElementById('security-confirm-btn');
         const securityCancel = document.getElementById('security-cancel-btn');
         const securityMessage = document.getElementById('security-message');
-        
+
         securityInput.focus();
-        
-        securityConfirm.onclick = () => {
+
+        securityConfirm.onclick = async () => {
             const restaurantId = securityInput.value.trim().toUpperCase();
             if (!restaurantId) {
                 securityMessage.textContent = 'Por favor ingresa un ID de restaurante válido';
@@ -77,28 +78,32 @@ document.addEventListener('DOMContentLoaded', async () => {
                 securityMessage.classList.add('error');
                 return;
             }
-            
-            const restaurants = loadRestaurants();
-            const restaurant = restaurants.find(r => r.id === restaurantId && r.active);
-            
-            if (restaurant) {
-                localStorage.setItem('monitorDetailsAuthenticated', 'true');
-                localStorage.setItem('monitorDetailsRestaurantId', restaurantId);
-                currentRestaurantId = restaurantId;
-                isAuthenticated = true;
-                
-                securityModal.classList.remove('active');
-                setTimeout(() => {
-                    securityModal.classList.add('hidden');
-                    initializeApp(restaurantId);
-                }, 300);
-            } else {
-                securityMessage.textContent = 'ID de restaurante inválido o restaurante inactivo';
+
+            try {
+                const docSnap = await getDoc(doc(db, 'restaurants', restaurantId));
+                const restaurant = docSnap.exists() ? docSnap.data() : null;
+                if (restaurant && restaurant.active) {
+                    currentRestaurantId = restaurantId;
+                    isAuthenticated = true;
+
+                    securityModal.classList.remove('active');
+                    setTimeout(() => {
+                        securityModal.classList.add('hidden');
+                        initializeApp(restaurantId);
+                    }, 300);
+                } else {
+                    securityMessage.textContent = 'ID de restaurante inválido o restaurante inactivo';
+                    securityMessage.classList.remove('hidden');
+                    securityMessage.classList.add('error');
+                }
+            } catch (e) {
+                console.error('Error verifying restaurant:', e);
+                securityMessage.textContent = 'Error verificando el ID del restaurante';
                 securityMessage.classList.remove('hidden');
                 securityMessage.classList.add('error');
             }
         };
-        
+
         securityCancel.onclick = () => {
             securityModal.classList.remove('active');
             setTimeout(() => {
@@ -109,49 +114,38 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
     // Initialize app after authentication
-    const initializeApp = (restaurantId) => {
-        // Update header with restaurant info
-        const restaurants = loadRestaurants();
-        const restaurant = restaurants.find(r => r.id === restaurantId);
-        
-        if (restaurant) {
-            restaurantNameElement.textContent = restaurant.name;
-            
-            // Add authenticated indicator
-            const authIndicator = document.createElement('div');
-            authIndicator.style.cssText = `
-                position: absolute;
-                top: 10px;
-                right: 10px;
-                background: #4CAF50;
-                color: white;
-                padding: 5px 10px;
-                border-radius: 15px;
-                font-size: 0.8em;
-                font-weight: bold;
-            `;
-            authIndicator.textContent = ` ${restaurantId}`;
-            monitorDetailsHeader.appendChild(authIndicator);
+    const initializeApp = async (restaurantId) => {
+        try {
+            const docSnap = await getDoc(doc(db, 'restaurants', restaurantId));
+            if (docSnap.exists()) {
+                const restaurant = docSnap.data();
+                restaurantNameElement.textContent = restaurant.name;
+
+                // Add authenticated indicator
+                const authIndicator = document.createElement('div');
+                authIndicator.style.cssText = `
+                    position: absolute;
+                    top: 10px;
+                    right: 10px;
+                    background: #4CAF50;
+                    color: white;
+                    padding: 5px 10px;
+                    border-radius: 15px;
+                    font-size: 0.8em;
+                    font-weight: bold;
+                `;
+                authIndicator.textContent = ` ${restaurantId}`;
+                monitorDetailsHeader.appendChild(authIndicator);
+            }
+
+            // Load settings and update header
+            await updateHeader();
+
+            // Listen to Firestore orders
+            listenToOrders(restaurantId);
+        } catch (e) {
+            console.error('Error initializing app:', e);
         }
-        
-          // Load settings
-          loadAppSettings();
-          updateHeader();
-
-          // Listen to Firestore orders
-          listenToOrders(restaurantId);
-      };
-
-    // Function to get the current user from localStorage
-    const getCurrentUser = () => {
-        const user = localStorage.getItem('currentUser');
-        return user ? JSON.parse(user) : null;
-    };
-
-    // Function to load restaurants
-    const loadRestaurants = () => {
-        const restaurants = localStorage.getItem('restaurants');
-        return restaurants ? JSON.parse(restaurants) : [];
     };
 
     // Firestore real-time listener for orders
@@ -180,13 +174,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     };
 
-    // Function to load settings from localStorage
-    const loadAppSettings = () => {
+    // Function to load settings from Firestore
+    const loadAppSettings = async () => {
         if (!currentRestaurantId) return {};
-        
-        const settingsKey = `restaurant_${currentRestaurantId}_appSettings`;
-        const settings = localStorage.getItem(settingsKey);
-        return settings ? JSON.parse(settings) : {};
+        try {
+            const restaurantRef = doc(db, 'restaurants', currentRestaurantId);
+            const docSnap = await getDoc(restaurantRef);
+            return docSnap.exists() ? (docSnap.data().settings || {}) : {};
+        } catch (error) {
+            console.error('Error loading settings:', error);
+            return {};
+        }
     };
 
     const getRestaurantVolume = async () => {
@@ -203,8 +201,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
     // Function to update restaurant name and logo on the monitor
-    const updateHeader = () => {
-        const settings = loadAppSettings();
+    const updateHeader = async () => {
+        const settings = await loadAppSettings();
         const restaurantName = settings.restaurantName || 'Monitor de Detalles de Pedidos';
         const restaurantLogoDataUrl = settings.restaurantLogoUrl;
 
@@ -343,9 +341,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
 
-    // Clear authentication on page load/refresh
-    clearAuthentication();
-
-    // Always show security modal on load
-    showSecurityModal();
+    if (await checkSecurityAccess()) {
+        initializeApp(currentRestaurantId);
+    } else {
+        showSecurityModal();
+    }
 });

--- a/script.js
+++ b/script.js
@@ -242,13 +242,15 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const restaurantRef = doc(db, 'restaurants', currentUser.id);
                 const docSnap = await getDoc(restaurantRef);
                 appSettings = docSnap.exists() ? (docSnap.data().settings || {}) : {};
-                localStorage.setItem(getSettingsKey(), JSON.stringify(appSettings));
             } catch (error) {
                 console.error('Error loading app settings:', error);
             }
         }
         currencyDisplaySpan.textContent = appSettings.currencySymbol || '$';
         floatingCurrencyDisplay.textContent = appSettings.currencySymbol || '$';
+        if (gainNode) {
+            gainNode.gain.value = parseFloat(appSettings.appVolume !== undefined ? appSettings.appVolume : 1);
+        }
     };
 
     const defaultMenuItems = [


### PR DESCRIPTION
## Summary
- validate detail monitor access with Firebase Auth
- fetch monitor settings from Firestore instead of localStorage
- drop localStorage storage of app settings and update audio volume from Firestore

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fa7846b208327b5915991b68759c5