### PR TITLE
Fix calculate modal in orders section

### DIFF
--- a/script.js
+++ b/script.js
@@ -310,7 +310,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         return `item_${Date.now()}`;
     };
 
-    const getMainMenuCheckboxes = () => document.querySelectorAll('#home-section .menu-categories input[type="checkbox"]');
+    const getMainMenuCheckboxes = () => Array.from(document.querySelectorAll('#home-section .menu-categories input[type="checkbox"]'));
 
     const renderMainMenu = (menu) => {
         mainMenuUlPlatos.innerHTML = '';


### PR DESCRIPTION
## Summary
- ensure getMainMenuCheckboxes returns an array to allow calculate modal to work in all browsers

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fcef318a483278955768cd8ccf280