### PR TITLE
Fix Chart.js loading for top items graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,9 +315,9 @@
         </div>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="module" src="script.js"></script>
     <script type="module">
-        import 'https://cdn.jsdelivr.net/npm/chart.js';
         import 'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js';
         import 'https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.14/jspdf.plugin.autotable.min.js';
 


### PR DESCRIPTION
## Summary
- ensure Chart.js loads before main script so top items chart renders

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fd3f563148327a0fb0bd24a848176