### PR TITLE
refactor: declare renderOrderTypeChart

### DIFF
--- a/script.js
+++ b/script.js
@@ -2424,7 +2424,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     })();
 
     // New: Function to render Order Type Distribution Chart
-    const renderOrderTypeChart = async () => {
+    async function renderOrderTypeChart() {
         const history = await loadOrderHistory();
         let dineInCount = 0;
         let takeawayCount = 0;
@@ -2512,7 +2512,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
             }
         });
-    };
+    }
 
     downloadTopItemsBtn.addEventListener('click', async () => {
         const topItemsData = {}; // Re-calculate based on today's orders


### PR DESCRIPTION
## Summary
- ensure renderOrderTypeChart is defined via function declaration for hoisting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fdad70d588327b4116dfb678a5fe8