### PR TITLE
feat: sync auth users to Firestore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.mpeg
+node_modules/
+functions/node_modules/

--- a/docs/user-sync.md
+++ b/docs/user-sync.md
@@ -1,0 +1,15 @@
+# User synchronization
+
+The Cloud Function `onAuthUserCreate` (see `functions/index.js`) keeps Firebase Authentication
+and Firestore in sync. Whenever a user is created in Auth, the function writes a document
+at `users/{uid}` with basic information such as `role`, `username` and `email`.
+
+## Role resolution
+- If the user has a `role` custom claim, that value is used.
+- Otherwise the role falls back to `functions.config().defaults.role` or `user`.
+
+## Manual user creation
+Users added manually—through the Firebase Console, CLI or Admin SDK—also trigger this function,
+so their corresponding Firestore document is created automatically.
+To backfill accounts created before deploying this trigger, run a one-off script that
+iterates over existing Auth users and writes the missing documents.

--- a/functions/index.js
+++ b/functions/index.js
@@ -4,6 +4,42 @@ const cors = require('cors')({ origin: true });
 
 admin.initializeApp();
 
+/**
+ * Creates a Firestore user document whenever a new Firebase Auth user is
+ * created. The role is taken from custom claims if present, otherwise from the
+ * configurable `defaults.role` parameter (defaults to `user`). This keeps
+ * manually created users in Firebase Authentication automatically synchronized
+ * with the `users/{uid}` collection.
+ */
+exports.onAuthUserCreate = functions.auth.user().onCreate(async (user) => {
+  const db = admin.firestore();
+
+  const defaultRole =
+    (functions.config().defaults && functions.config().defaults.role) ||
+    'user';
+
+  const role = (user.customClaims && user.customClaims.role) || defaultRole;
+
+  const username =
+    user.displayName || (user.email ? user.email.split('@')[0] : 'anonymous');
+
+  const docRef = db.collection('users').doc(user.uid);
+  const snapshot = await docRef.get();
+
+  const data = {
+    username,
+    email: user.email || null,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  };
+
+  // Set the role only if it doesn't exist to avoid overwriting existing roles.
+  if (!snapshot.exists || !snapshot.data().role) {
+    data.role = role;
+  }
+
+  await docRef.set(data, { merge: true });
+});
+
 exports.createRestaurantAdmin = functions.https.onRequest((req, res) => {
   return cors(req, res, async () => {
     if (req.method !== 'POST') {


### PR DESCRIPTION
## Summary
- create Firestore `users/{uid}` doc when new auth user is created
- document user/role sync and manual user handling
- ignore node_modules directories

## Testing
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68a0d8161598832780a046484eacbfa5