### PR TITLE
Enable monitor access via restaurant ID

### DIFF
--- a/monitor.html
+++ b/monitor.html
@@ -8,6 +8,7 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 </head>
 <body>
+    <!-- La URL debe incluir ?rest=<ID> para indicar el restaurante a monitorear -->
     <div class="monitor-container">
         <div class="monitor-header">
             <img id="restaurant-logo" src="" alt="Logo del Restaurante" class="hidden">


### PR DESCRIPTION
## Summary
- Allow monitor to load orders and settings based on `?rest=` URL parameter without authentication
- Query Firestore orders by `restaurantId` and fetch restaurant settings directly
- Document `?rest=<ID>` requirement in monitor HTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d7b80d888327b4328522e96aa69d