### PR TITLE
Add copy link icons for monitor pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,18 @@
                 <ul>
                     <li><a href="#" id="nav-home" class="active" data-section-id="home-section"><i class="fas fa-home"></i> Inicio</a></li>
                     <li><a href="#" id="nav-history" data-section-id="order-history"><i class="fas fa-history"></i> Historial de Pedidos</a></li>
-                    <li><a href="#" id="nav-monitor"><i class="fas fa-tv"></i> Monitor</a></li>
-                    <li><a href="#" id="nav-detail-monitor"><i class="fas fa-clipboard-list"></i> Monitor de Detalles</a></li>
+                    <li>
+                        <a href="#" id="nav-monitor" class="with-copy">
+                            <span><i class="fas fa-tv"></i> Monitor</span>
+                            <i class="fas fa-copy copy-link-icon" id="copy-monitor-link"></i>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#" id="nav-detail-monitor" class="with-copy">
+                            <span><i class="fas fa-clipboard-list"></i> Monitor de Detalles</span>
+                            <i class="fas fa-copy copy-link-icon" id="copy-detail-monitor-link"></i>
+                        </a>
+                    </li>
                     <li><a href="#" id="nav-daily-summary" data-section-id="daily-summary"><i class="fas fa-chart-bar"></i> Resumen del Día</a></li>
                     <li><a href="#" id="nav-top-items" data-section-id="top-items"><i class="fas fa-star"></i> Artículos Más Vendidos</a></li>
                     <li><a href="#" id="nav-menu-management" data-section-id="menu-management"><i class="fas fa-edit"></i> Gestionar Menú</a></li>

--- a/script.js
+++ b/script.js
@@ -107,6 +107,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const navMenuManagement = document.getElementById('nav-menu-management');
     const navMonitor = document.getElementById('nav-monitor');
     const navDetailMonitor = document.getElementById('nav-detail-monitor');
+    const copyMonitorLink = document.getElementById('copy-monitor-link');
+    const copyDetailMonitorLink = document.getElementById('copy-detail-monitor-link');
 
     // New: Elements for Order Type Distribution Chart
     const orderTypeChartCanvas = document.getElementById('orderTypeChart');
@@ -141,6 +143,35 @@ document.addEventListener('DOMContentLoaded', async () => {
     // New: Login attempts counter
     let loginAttempts = 0;
     const MAX_LOGIN_ATTEMPTS = 5;
+
+    const setupCopyLink = (iconElement, path) => {
+        iconElement.addEventListener('click', async (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (currentUser && (currentUser.role === 'restaurant' || currentUser.role === 'admin')) {
+                if (currentUser.id) {
+                    const url = `${window.location.origin}/${path}?rest=${currentUser.id}`;
+                    try {
+                        await navigator.clipboard.writeText(url);
+                        iconElement.classList.replace('fa-copy', 'fa-check');
+                        setTimeout(() => {
+                            iconElement.classList.replace('fa-check', 'fa-copy');
+                        }, 1000);
+                    } catch (err) {
+                        console.error('Error al copiar el enlace:', err);
+                    }
+                } else {
+                    alert('No se encontró el ID del restaurante.');
+                }
+            } else {
+                alert('Por favor, inicia sesión para copiar el enlace.');
+                openLoginModal();
+            }
+        });
+    };
+
+    setupCopyLink(copyMonitorLink, 'monitor.html');
+    setupCopyLink(copyDetailMonitorLink, 'monitor_details.html');
 
     const hideSplashScreen = () => {
         splashScreen.classList.add('hidden');

--- a/style.css
+++ b/style.css
@@ -92,6 +92,23 @@ body {
     font-size: 1.3em;
 }
 
+/* Navigation links with copy icons */
+.sidebar-nav a.with-copy {
+    justify-content: space-between;
+}
+
+.sidebar-nav a.with-copy .copy-link-icon {
+    margin-right: 0;
+    margin-left: 10px;
+    font-size: 1.1em;
+    cursor: pointer;
+    transition: color 0.2s ease;
+}
+
+.sidebar-nav a.with-copy .copy-link-icon:hover {
+    color: #FFD700;
+}
+
 .sidebar-nav a:hover {
     background-color: rgba(255, 255, 255, 0.15);
     border-left-color: #FFD700; /* Gold accent on hover */


### PR DESCRIPTION
## Summary
- Add copy-to-clipboard icons next to Monitor and Monitor de Detalles sidebar links
- Style sidebar links with copy icon hover and spacing
- Implement clipboard logic with success check animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f26f05548327810ac840cf217b85