### PR TITLE
Fix login background on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -175,10 +175,16 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const hideSplashScreen = () => {
         splashScreen.classList.add('hidden');
-        splashScreen.addEventListener('transitionend', () => {
-            splashScreen.style.display = 'none';
-            containerWrapper.classList.remove('hidden');
-        }, { once: true });
+        splashScreen.addEventListener(
+            'transitionend',
+            () => {
+                splashScreen.style.display = 'none';
+                if (currentUser) {
+                    containerWrapper.classList.remove('hidden');
+                }
+            },
+            { once: true }
+        );
     };
 
     // Initialize and hide splash screen based on device
@@ -186,7 +192,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         setTimeout(hideSplashScreen, 3000);
     } else {
         splashScreen.style.display = 'none';
-        containerWrapper.classList.remove('hidden');
+        if (currentUser) {
+            containerWrapper.classList.remove('hidden');
+        }
     }
 
     const getStorageKey = (key) => {


### PR DESCRIPTION
## Summary
- prevent the home menu from showing behind the login dialog on mobile by only revealing content when a user is authenticated

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7406b516c832796d1dd78e26e8f2a