### PR TITLE
Restrict detail monitor to authenticated users

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,9 +35,8 @@
                         </a>
                     </li>
                     <li>
-                        <a href="#" id="nav-detail-monitor" class="with-copy">
+                        <a href="#" id="nav-detail-monitor">
                             <span><i class="fas fa-clipboard-list"></i> Monitor de Detalles</span>
-                            <i class="fas fa-copy copy-link-icon" id="copy-detail-monitor-link"></i>
                         </a>
                     </li>
                     <li><a href="#" id="nav-daily-summary" data-section-id="daily-summary"><i class="fas fa-chart-bar"></i> Resumen del Día</a></li>

--- a/monitor_details.js
+++ b/monitor_details.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const currentRestaurantId = new URLSearchParams(window.location.search).get('rest');
     let orderHistory = [];
 
-    const { db } = await import('./firebase-init.js');
+    const { db, auth, onAuthStateChanged } = await import('./firebase-init.js');
     const { collection, onSnapshot, query, where, getDocs, doc, updateDoc, getDoc } = await import('https://www.gstatic.com/firebasejs/9.6.1/firebase-firestore.js');
     const initializeApp = async (restaurantId) => {
         try {
@@ -236,9 +236,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
 
-    if (currentRestaurantId) {
-        initializeApp(currentRestaurantId);
-    } else {
-        detailMonitorListDiv.innerHTML = '<p style="color: #6A1B9A; font-weight: bold;">No se proporcionó el ID del restaurante en la URL.</p>';
-    }
+    onAuthStateChanged(auth, (user) => {
+        if (!user) {
+            window.location.href = 'index.html';
+            return;
+        }
+        if (currentRestaurantId) {
+            initializeApp(currentRestaurantId);
+        } else {
+            detailMonitorListDiv.innerHTML = '<p style="color: #6A1B9A; font-weight: bold;">No se proporcionó el ID del restaurante en la URL.</p>';
+        }
+    });
 });

--- a/script.js
+++ b/script.js
@@ -108,7 +108,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     const navMonitor = document.getElementById('nav-monitor');
     const navDetailMonitor = document.getElementById('nav-detail-monitor');
     const copyMonitorLink = document.getElementById('copy-monitor-link');
-    const copyDetailMonitorLink = document.getElementById('copy-detail-monitor-link');
 
     // New: Elements for Order Type Distribution Chart
     const orderTypeChartCanvas = document.getElementById('orderTypeChart');
@@ -171,7 +170,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
     setupCopyLink(copyMonitorLink, 'monitor.html');
-    setupCopyLink(copyDetailMonitorLink, 'monitor_details.html');
 
     const hideSplashScreen = () => {
         splashScreen.classList.add('hidden');


### PR DESCRIPTION
## Summary
- Redirect unauthenticated users away from the detail monitor
- Remove link copy controls for the detail monitor

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/food/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a748c488c48327a1555a3a62d8566f