### PR TITLE
Add restaurant filter for top items chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,9 @@
             <!-- New Section for Top Items -->
             <div id="top-items" class="content-section hidden">
                 <h2>Artículos Más Vendidos</h2>
+                <select id="top-items-restaurant-filter">
+                    <option value="all">Todos</option>
+                </select>
                 <canvas id="topItemsChart"></canvas>
                 <p id="no-top-items-message" class="hidden">No hay datos suficientes para generar el gráfico de artículos más vendidos.</p>
                 <button id="reset-top-items-btn"><i class="fas fa-redo-alt"></i> Reiniciar Datos de Artículos Vendidos</button>


### PR DESCRIPTION
## Summary
- Add dropdown to filter top items by restaurant or view all
- Populate filter options and reload chart based on selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa19a6b9308327b5642212fe316e67