### PR TITLE
Stack top items buttons vertically

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,9 +182,11 @@
                 </select>
                 <canvas id="topItemsChart"></canvas>
                 <p id="no-top-items-message" class="hidden">No hay datos suficientes para generar el gráfico de artículos más vendidos.</p>
-                <button id="reset-top-items-btn"><i class="fas fa-redo-alt"></i> Reiniciar Datos de Artículos Vendidos</button>
-                <!-- New: Download Top Items Button -->
-                <button id="download-top-items-btn" class="download-button"><i class="fas fa-download"></i> Descargar Artículos</button>
+                <div class="top-items-button-container">
+                    <button id="reset-top-items-btn"><i class="fas fa-redo-alt"></i> Reiniciar Datos de Artículos Vendidos</button>
+                    <!-- New: Download Top Items Button -->
+                    <button id="download-top-items-btn" class="download-button"><i class="fas fa-download"></i> Descargar Artículos</button>
+                </div>
 
                 <!-- New: Order Type Distribution Chart -->
                 <h3 class="chart-section-title">Distribución de Pedidos por Tipo</h3>

--- a/style.css
+++ b/style.css
@@ -1340,6 +1340,18 @@ h2 {
     background: linear-gradient(to right, #512DA8, #7E57C2);
 }
 
+/* Arrange Top Items buttons vertically */
+.top-items-button-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.top-items-button-container .download-button {
+    margin-left: 0;
+    margin-top: 10px;
+}
+
 /* Utility class to hide elements */
 .hidden {
     display: none;


### PR DESCRIPTION
## Summary
- Wrap top items reset and download buttons in a container to stack them vertically.
- Add styles to arrange the buttons in a column and remove extra horizontal spacing.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af940428dc83278c46f86f47dcf5d2