### PR TITLE
Add admin-only restaurant selector for top items

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
             <!-- New Section for Top Items -->
             <div id="top-items" class="content-section hidden">
                 <h2>Artículos Más Vendidos</h2>
-                <select id="top-items-restaurant-filter">
+                <select id="top-items-restaurant-filter" class="hidden">
                     <option value="all">Todos</option>
                 </select>
                 <canvas id="topItemsChart"></canvas>


### PR DESCRIPTION
## Summary
- Hide top items restaurant selector by default to ensure it's only visible for admin users

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af98abcab08327824148c193604adf