### PR TITLE
Add admin-only restaurant selector for top items

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
             <!-- New Section for Top Items -->
             <div id="top-items" class="content-section hidden">
                 <h2>Artículos Más Vendidos</h2>
-                <select id="top-items-restaurant-filter">
+                <select id="top-items-restaurant-filter" class="hidden">
                     <option value="all">Todos</option>
                 </select>
                 <canvas id="topItemsChart"></canvas>

--- a/script.js
+++ b/script.js
@@ -2276,9 +2276,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     resetTopItemsBtn.addEventListener('click', resetTopItems);
 
     if (topItemsRestaurantFilter) {
-        topItemsRestaurantFilter.addEventListener('change', () => {
-            renderTopItemsChart();
-            renderOrderTypeChart();
+        topItemsRestaurantFilter.addEventListener('change', async () => {
+            await renderTopItemsChart();
+            await renderOrderTypeChart();
         });
     }
 


### PR DESCRIPTION
## Summary
- Add asynchronous listener so restaurant selector refreshes top items and order type charts for admins
- Hide restaurant selector by default so only admins see it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af98abcab08327824148c193604adf